### PR TITLE
refactor: Payment.jsx의 모든 CSS 클래스에 payment- 접두사를 추가

### DIFF
--- a/frontend/src/components/Payment.css
+++ b/frontend/src/components/Payment.css
@@ -19,7 +19,7 @@
   font-weight: 700;
 }
 
-.back-button {
+.payment-back-button {
   background: none;
   border: none;
   padding: 0.5rem;
@@ -28,7 +28,7 @@
   transition: color 0.2s;
 }
 
-.back-button:hover {
+.payment-back-button:hover {
   color: #15803D;
 }
 
@@ -65,13 +65,13 @@
 }
 
 /* 예약 정보 요약 */
-.booking-summary {
+.payment-booking-summary {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.summary-item {
+.payment-summary-item {
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -81,65 +81,65 @@
   border-left: 4px solid #15803D;
 }
 
-.summary-icon {
+.payment-summary-icon {
   width: 1.25rem;
   height: 1.25rem;
   color: #15803D;
   flex-shrink: 0;
 }
 
-.summary-info {
+.payment-summary-info {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
 
-.summary-label {
+.payment-summary-label {
   font-size: 0.875rem;
   color: #6b7280;
   font-weight: 500;
 }
 
-.summary-value {
+.payment-summary-value {
   font-size: 1rem;
   color: #2d3748;
   font-weight: 600;
 }
 
 /* 가격 정보 */
-.price-breakdown {
+.payment-price-breakdown {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
 
-.price-item {
+.payment-price-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
   color: #2d3748;
 }
 
-.price-item:not(.total) {
+.payment-price-item:not(.total) {
   font-size: 0.95rem;
 }
 
-.price-item.total {
+.payment-price-item.total {
   font-size: 1.1rem;
   font-weight: 700;
   color: #15803D;
 }
 
-.price-item.discount {
+.payment-price-item.discount {
   color: #f59e0b;
   font-weight: 600;
 }
 
-.price-item.discount span:last-child {
+.payment-price-item.discount span:last-child {
   color: #f59e0b;
 }
 
-.price-item.final-amount {
+.payment-price-item.final-amount {
   background: linear-gradient(135deg, #10b981, #34d399);
   color: white !important;
   padding: 12px 16px;
@@ -148,21 +148,21 @@
   font-weight: 700;
 }
 
-.price-item.final-amount span {
+.payment-price-item.final-amount span {
   color: white !important;
 }
 
-.price-final {
+.payment-price-final {
   font-size: 1.2rem !important;
   font-weight: 700 !important;
 }
 
-.price-discount {
+.payment-price-discount {
   color: #f59e0b !important;
   font-weight: 700;
 }
 
-.price-divider {
+.payment-price-divider {
   height: 1px;
   background: #e5e7eb;
   margin: 0.5rem 0;
@@ -191,13 +191,13 @@
   background: rgba(21, 128, 61, 0.1);
 }
 
-.toss-logo {
+.payment-toss-logo {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.toss-circle {
+.payment-toss-circle {
   width: 24px;
   height: 24px;
   background: #3182f6;
@@ -205,7 +205,7 @@
   position: relative;
 }
 
-.toss-circle::before {
+.payment-toss-circle::before {
   content: '';
   position: absolute;
   top: 50%;
@@ -217,7 +217,7 @@
   border-radius: 50%;
 }
 
-.toss-text {
+.payment-toss-text {
   font-weight: 700;
   color: #3182f6;
   font-size: 1.1rem;
@@ -250,11 +250,11 @@
 }
 
 /* 쿠폰 선택 */
-.coupon-section {
+.payment-coupon-section {
   width: 100%;
 }
 
-.coupon-select-btn {
+.payment-coupon-select-btn {
   width: 100%;
   padding: 1rem;
   background: rgba(255, 255, 255, 0.9);
@@ -270,17 +270,17 @@
   gap: 0.5rem;
 }
 
-.coupon-select-btn:hover {
+.payment-coupon-select-btn:hover {
   background: rgba(21, 128, 61, 0.05);
   border-color: #166534;
 }
 
-.coupon-icon {
+.payment-coupon-icon {
   width: 1.25rem;
   height: 1.25rem;
 }
 
-.selected-coupon {
+.payment-coupon-selected {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -290,23 +290,23 @@
   border-radius: 12px;
 }
 
-.coupon-info {
+.payment-coupon-info {
   flex: 1;
 }
 
-.coupon-name {
+.payment-coupon-name {
   font-weight: 700;
   color: #2d3748;
   margin-bottom: 0.25rem;
 }
 
-.coupon-discount {
+.payment-coupon-discount {
   font-size: 0.9rem;
   color: #dc2626;
   font-weight: 600;
 }
 
-.coupon-remove-btn {
+.payment-coupon-remove-btn {
   background: none;
   border: none;
   color: #dc2626;
@@ -316,12 +316,12 @@
   transition: background 0.2s;
 }
 
-.coupon-remove-btn:hover {
+.payment-coupon-remove-btn:hover {
   background: rgba(220, 38, 38, 0.1);
 }
 
 /* 쿠폰 모달 */
-.modal-overlay {
+.payment-modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -335,7 +335,7 @@
   padding: 1rem;
 }
 
-.modal-content {
+.payment-modal-content {
   background: white;
   border-radius: 16px;
   width: 100%;
@@ -345,7 +345,7 @@
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
 }
 
-.modal-header {
+.payment-modal-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -353,13 +353,13 @@
   border-bottom: 1px solid #e5e7eb;
 }
 
-.modal-header h3 {
+.payment-modal-header h3 {
   margin: 0;
   color: #2d3748;
   font-weight: 700;
 }
 
-.modal-close {
+.payment-modal-close {
   background: none;
   border: none;
   color: #6b7280;
@@ -369,24 +369,24 @@
   transition: all 0.2s;
 }
 
-.modal-close:hover {
+.payment-modal-close:hover {
   background: #f3f4f6;
   color: #374151;
 }
 
-.modal-body {
+.payment-modal-body {
   padding: 1.5rem;
   max-height: 60vh;
   overflow-y: auto;
 }
 
-.coupon-list {
+.payment-coupon-list {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.coupon-item {
+.payment-coupon-item {
   border: 2px solid #e5e7eb;
   border-radius: 12px;
   padding: 1rem;
@@ -395,31 +395,31 @@
   background: white;
 }
 
-.coupon-item:hover {
+.payment-coupon-item:hover {
   border-color: #15803D;
   background: rgba(21, 128, 61, 0.02);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(21, 128, 61, 0.15);
 }
 
-.coupon-content {
+.payment-coupon-content {
   width: 100%;
 }
 
-.coupon-header {
+.payment-coupon-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 0.5rem;
 }
 
-.coupon-item .coupon-name {
+.payment-coupon-item .payment-coupon-name {
   font-weight: 700;
   color: #2d3748;
   font-size: 1rem;
 }
 
-.coupon-value {
+.payment-coupon-value {
   background: #15803D;
   color: white;
   padding: 0.25rem 0.75rem;
@@ -428,13 +428,13 @@
   font-size: 0.9rem;
 }
 
-.coupon-description {
+.payment-coupon-description {
   color: #6b7280;
   font-size: 0.9rem;
   margin-bottom: 0.75rem;
 }
 
-.coupon-details {
+.payment-coupon-details {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -442,22 +442,22 @@
   color: #9ca3af;
 }
 
-.no-coupons {
+.payment-no-coupons {
   text-align: center;
   padding: 2rem;
   color: #6b7280;
 }
 
-.no-coupon-icon {
+.payment-no-coupon-icon {
   color: #d1d5db;
   margin-bottom: 1rem;
 }
 
-.no-coupons p {
+.payment-no-coupons p {
   margin: 0.5rem 0;
 }
 
-.no-coupon-desc {
+.payment-no-coupon-desc {
   font-size: 0.9rem;
   color: #9ca3af;
 }
@@ -520,17 +520,17 @@
 
 /* 반응형 스타일 */
 @media (max-width: 480px) {
-  .summary-item {
+  .payment-summary-item {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
   }
 
-  .price-item {
+  .payment-price-item {
     font-size: 0.9rem;
   }
 
-  .price-item.total {
+  .payment-price-item.total {
     font-size: 1rem;
   }
 
@@ -538,37 +538,37 @@
     padding: 1rem;
   }
 
-  .toss-text {
+  .payment-toss-text {
     font-size: 1rem;
   }
 
-  .modal-content {
+  .payment-modal-content {
     margin: 1rem;
     max-height: 90vh;
   }
 
-  .modal-header {
+  .payment-modal-header {
     padding: 1rem;
   }
 
-  .modal-body {
+  .payment-modal-body {
     padding: 1rem;
     max-height: 70vh;
   }
 
-  .coupon-header {
+  .payment-coupon-header {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
   }
 
-  .selected-coupon {
+  .payment-coupon-selected {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.75rem;
   }
 
-  .coupon-remove-btn {
+  .payment-coupon-remove-btn {
     align-self: flex-end;
   }
 }

--- a/frontend/src/components/Payment.jsx
+++ b/frontend/src/components/Payment.jsx
@@ -192,8 +192,9 @@ const Payment = ({ bookingData, onBack, onTossPayment }) => {
       reservationId: bookingData.reservationId || bookingData.reservation?.id,
       ticketId: bookingData.ticketId || bookingData.ticket?.id,
       
-      // 🔥 결제 금액 정보 (원가 전달 - 백엔드에서 쿠폰 처리)
-      servicePrice: servicePrice, // 원가 (할인 전)
+      // 🔥 결제 금액 정보 (할인된 최종 금액 전달)
+      servicePrice: totalPrice,   // 할인된 최종 금액 (백엔드 결제 진행용)
+      originalPrice: servicePrice, // 원가 (표시용)
       finalPrice: totalPrice,     // 최종 금액 (할인 후) - 표시용
       serviceName,
       selectedCoupon,
@@ -236,7 +237,7 @@ const Payment = ({ bookingData, onBack, onTossPayment }) => {
   return (
     <div className="payment-container">
       <div className="payment-header">
-        <button className="back-button" onClick={onBack}>
+        <button className="payment-back-button" onClick={onBack}>
           <ArrowLeft className="icon" />
         </button>
         <h1>결제하기</h1>
@@ -246,38 +247,38 @@ const Payment = ({ bookingData, onBack, onTossPayment }) => {
         {/* 예약 정보 확인 */}
         <div className="payment-section">
           <h3><CheckCircle className="icon" /> 예약 정보 확인</h3>
-          <div className="booking-summary">
-            <div className="summary-item">
-              <User className="summary-icon" />
-              <div className="summary-info">
-                <span className="summary-label">멘토</span>
-                <span className="summary-value">{bookingData?.mentor?.name || '선택된 멘토'}</span>
+          <div className="payment-booking-summary">
+            <div className="payment-summary-item">
+              <User className="payment-summary-icon" />
+              <div className="payment-summary-info">
+                <span className="payment-summary-label">멘토</span>
+                <span className="payment-summary-value">{bookingData?.mentor?.name || '선택된 멘토'}</span>
               </div>
             </div>
 
-            <div className="summary-item">
-              <Calendar className="summary-icon" />
-              <div className="summary-info">
-                <span className="summary-label">날짜</span>
-                <span className="summary-value">{bookingData?.date}</span>
+            <div className="payment-summary-item">
+              <Calendar className="payment-summary-icon" />
+              <div className="payment-summary-info">
+                <span className="payment-summary-label">날짜</span>
+                <span className="payment-summary-value">{bookingData?.date}</span>
               </div>
             </div>
 
-            <div className="summary-item">
-              <Clock className="summary-icon" />
-              <div className="summary-info">
-                <span className="summary-label">시간</span>
-                <span className="summary-value">
+            <div className="payment-summary-item">
+              <Clock className="payment-summary-icon" />
+              <div className="payment-summary-info">
+                <span className="payment-summary-label">시간</span>
+                <span className="payment-summary-value">
                   {bookingData?.startTime} - {bookingData?.endTime}
                 </span>
               </div>
             </div>
 
-            <div className="summary-item">
-              <Clock className="summary-icon" />
-              <div className="summary-info">
-                <span className="summary-label">서비스</span>
-                <span className="summary-value">{serviceName}</span>
+            <div className="payment-summary-item">
+              <Clock className="payment-summary-icon" />
+              <div className="payment-summary-info">
+                <span className="payment-summary-label">서비스</span>
+                <span className="payment-summary-value">{serviceName}</span>
               </div>
             </div>
           </div>
@@ -286,18 +287,18 @@ const Payment = ({ bookingData, onBack, onTossPayment }) => {
         {/* 결제 금액 */}
         <div className="payment-section">
           <h3>결제 금액</h3>
-          <div className="price-breakdown">
-            <div className="price-item">
+          <div className="payment-price-breakdown">
+            <div className="payment-price-item">
               <span>서비스 이용료</span>
               <span>{servicePrice.toLocaleString()}원</span>
             </div>
             {couponDiscount > 0 && (
-              <div className="price-item discount">
+              <div className="payment-price-item discount">
                 <span>쿠폰 할인</span>
                 <span>-{couponDiscount.toLocaleString()}원</span>
               </div>
             )}
-            <div className="price-item total">
+            <div className="payment-price-item total">
               <span>총 결제금액</span>
               <span>{totalPrice.toLocaleString()}원</span>
             </div>
@@ -307,28 +308,28 @@ const Payment = ({ bookingData, onBack, onTossPayment }) => {
         {/* 쿠폰 선택 */}
         <div className="payment-section">
           <h3><Gift className="icon" /> 쿠폰 사용</h3>
-          <div className="coupon-section">
+          <div className="payment-coupon-section">
             {selectedCoupon ? (
-              <div className="selected-coupon">
-                <div className="coupon-info">
-                  <div className="coupon-name">{selectedCoupon.name}</div>
-                  <div className="coupon-discount">
+              <div className="payment-coupon-selected">
+                <div className="payment-coupon-info">
+                  <div className="payment-coupon-name">{selectedCoupon.name}</div>
+                  <div className="payment-coupon-discount">
                     {selectedCoupon.type === 'fixed'
                       ? `${selectedCoupon.discount.toLocaleString()}원 할인`
                       : `${selectedCoupon.discount}% 할인 (최대 ${selectedCoupon.maxDiscount?.toLocaleString() || '무제한'}원)`
                     }
                   </div>
                 </div>
-                <button className="coupon-remove-btn" onClick={handleCouponRemove}>
+                <button className="payment-coupon-remove-btn" onClick={handleCouponRemove}>
                   <X size={16} />
                 </button>
               </div>
             ) : (
               <button
-                className="coupon-select-btn"
+                className="payment-coupon-select-btn"
                 onClick={() => setIsCouponModalOpen(true)}
               >
-                <Gift className="coupon-icon" />
+                <Gift className="payment-coupon-icon" />
                 사용 가능한 쿠폰 선택하기
               </button>
             )}
@@ -340,9 +341,9 @@ const Payment = ({ bookingData, onBack, onTossPayment }) => {
           <h3><CreditCard className="icon" /> 결제 방법</h3>
           <div className="payment-methods">
             <div className="payment-method selected">
-              <div className="toss-logo">
-                <div className="toss-circle"></div>
-                <span className="toss-text">toss</span>
+              <div className="payment-toss-logo">
+                <div className="payment-toss-circle"></div>
+                <span className="payment-toss-text">toss</span>
               </div>
               <span>토스페이</span>
             </div>
@@ -373,39 +374,39 @@ const Payment = ({ bookingData, onBack, onTossPayment }) => {
 
       {/* 쿠폰 선택 모달 */}
       {isCouponModalOpen && (
-        <div className="modal-overlay" onClick={() => setIsCouponModalOpen(false)}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <div className="modal-header">
+        <div className="payment-modal-overlay" onClick={() => setIsCouponModalOpen(false)}>
+          <div className="payment-modal-content" onClick={(e) => e.stopPropagation()}>
+            <div className="payment-modal-header">
               <h3>사용 가능한 쿠폰</h3>
               <button
-                className="modal-close"
+                className="payment-modal-close"
                 onClick={() => setIsCouponModalOpen(false)}
               >
                 <X size={24} />
               </button>
             </div>
 
-            <div className="modal-body">
+            <div className="payment-modal-body">
               {getUsableCoupons().length > 0 ? (
-                <div className="coupon-list">
+                <div className="payment-coupon-list">
                   {getUsableCoupons().map(coupon => (
                     <div
                       key={coupon.id}
-                      className="coupon-item"
+                      className="payment-coupon-item"
                       onClick={() => handleCouponSelect(coupon)}
                     >
-                      <div className="coupon-content">
-                        <div className="coupon-header">
-                          <span className="coupon-name">{coupon.name}</span>
-                          <span className="coupon-value">
+                      <div className="payment-coupon-content">
+                        <div className="payment-coupon-header">
+                          <span className="payment-coupon-name">{coupon.name}</span>
+                          <span className="payment-coupon-value">
                             {coupon.type === 'fixed'
                               ? `${coupon.discount.toLocaleString()}원`
                               : `${coupon.discount}%`
                             }
                           </span>
                         </div>
-                        <div className="coupon-description">{coupon.description}</div>
-                        <div className="coupon-details">
+                        <div className="payment-coupon-description">{coupon.description}</div>
+                        <div className="payment-coupon-details">
                           <span>최소 주문금액: {coupon.minAmount.toLocaleString()}원</span>
                           <span>만료일: {coupon.expiryDate}</span>
                         </div>
@@ -414,10 +415,10 @@ const Payment = ({ bookingData, onBack, onTossPayment }) => {
                   ))}
                 </div>
               ) : (
-                <div className="no-coupons">
-                  <Gift size={48} className="no-coupon-icon" />
+                <div className="payment-no-coupons">
+                  <Gift size={48} className="payment-no-coupon-icon" />
                   <p>사용 가능한 쿠폰이 없습니다.</p>
-                  <p className="no-coupon-desc">
+                  <p className="payment-no-coupon-desc">
                     현재 주문 금액({servicePrice.toLocaleString()}원)으로는<br />
                     사용할 수 있는 쿠폰이 없어요.
                   </p>

--- a/frontend/src/components/PaymentComplete.css
+++ b/frontend/src/components/PaymentComplete.css
@@ -21,7 +21,7 @@
   padding: 3rem;
 }
 
-.loading-spinner {
+.payment-complete-loading-spinner {
   width: 50px;
   height: 50px;
   border: 4px solid rgba(255, 255, 255, 0.3);
@@ -37,7 +37,7 @@
 }
 
 /* 성공 헤더 */
-.success-header {
+.payment-complete-success-header {
   text-align: center;
   margin-bottom: 2rem;
 }
@@ -420,4 +420,142 @@
     flex-direction: column;
     text-align: center;
   }
+}
+
+/* 필요한 추가 클래스들 */
+.payment-section {
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(20px);
+  border-radius: 20px;
+  margin-bottom: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.payment-section h3 {
+  margin: 0 0 1.5rem 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #2d3748;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.payment-button {
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  color: white;
+  border: none;
+  padding: 0.875rem 1.5rem;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  box-shadow: 0 4px 15px rgba(16, 185, 129, 0.3);
+}
+
+.payment-button:hover {
+  background: linear-gradient(135deg, #059669 0%, #047857 100%);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(16, 185, 129, 0.4);
+}
+
+.booking-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.summary-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  background: rgba(248, 250, 252, 0.8);
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+}
+
+.summary-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: #667eea;
+  flex-shrink: 0;
+}
+
+.summary-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+}
+
+.summary-label {
+  font-size: 0.875rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.summary-value {
+  font-size: 1rem;
+  color: #1e293b;
+  font-weight: 600;
+}
+
+.price-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(248, 250, 252, 0.8);
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+}
+
+.price-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1rem;
+}
+
+.price-item.discount {
+  color: #059669;
+  font-weight: 600;
+}
+
+.price-item.total {
+  font-size: 1.25rem;
+  font-weight: 700;
+  padding-top: 0.75rem;
+  border-top: 2px solid #e2e8f0;
+  color: #1e293b;
+}
+
+.payment-info {
+  background: rgba(248, 250, 252, 0.8);
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+}
+
+.payment-info p {
+  margin: 0 0 1rem 0;
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+.payment-info p:last-child {
+  margin-bottom: 0;
+}
+
+.icon {
+  width: 1.25rem;
+  height: 1.25rem;
 }

--- a/frontend/src/components/PaymentComplete.jsx
+++ b/frontend/src/components/PaymentComplete.jsx
@@ -9,7 +9,7 @@ import {
   Receipt,
   ArrowLeft
 } from 'lucide-react';
-import './Payment.css'; // Payment.css 사용
+import './PaymentComplete.css'; // PaymentComplete 전용 CSS 사용
 import ReceiptModal from './ReceiptModal'; // 영수증 모달 컴포넌트 import
 
 const PaymentComplete = ({paymentData, onHome, onPaymentHistory}) => {
@@ -29,15 +29,43 @@ const PaymentComplete = ({paymentData, onHome, onPaymentHistory}) => {
     console.groupEnd();
   }
 
+  // 안전한 숫자 포맷팅 함수
+  const safeFormatNumber = (value, defaultValue = 0) => {
+    if (value === null || value === undefined || value === '') return defaultValue.toLocaleString();
+    const numValue = Number(value);
+    if (isNaN(numValue)) return defaultValue.toLocaleString();
+    return numValue.toLocaleString();
+  };
+
+  // 안전한 숫자 검증 함수
+  const safeNumber = (value) => {
+    if (value === null || value === undefined || value === '') return 0;
+    const numValue = Number(value);
+    return isNaN(numValue) ? 0 : numValue;
+  };
+
   const formatDate = (dateString) => {
-    // 유효한 날짜 문자열이 아닐 경우 빈 문자열 반환
+    // 유효한 날짜 문자열이 아닐 경우 현재 시간 반환
     if (!dateString || dateString === '날짜 미정' || dateString === '시간 미정') {
-      return '';
+      return new Date().toLocaleString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
     }
     const date = new Date(dateString);
     // Date 객체가 유효한지 확인 (Invalid Date 방지)
     if (isNaN(date.getTime())) {
-      return dateString; // 유효하지 않은 날짜면 원본 문자열 반환 (디버깅 용이)
+      console.warn('⚠️ 유효하지 않은 날짜 형식:', dateString);
+      return new Date().toLocaleString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
     }
     return date.toLocaleString('ko-KR', {
       year: 'numeric',
@@ -159,18 +187,14 @@ const PaymentComplete = ({paymentData, onHome, onPaymentHistory}) => {
 
   // paymentData가 없는 경우 에러 처리
   if (!paymentData) {
+    console.error('❌ PaymentComplete: paymentData가 전달되지 않았습니다.');
     return (
-        <div className="payment-container">
-          <div className="payment-header">
-            <button onClick={onHome} className="back-button">
-              <ArrowLeft className="icon" />
-            </button>
-            <h1>결제 완료</h1>
-          </div>
-          <div className="payment-content">
-            <div className="payment-section">
+        <div className="payment-complete-container">
+          <div className="payment-complete-content">
+            <div className="error-section">
               <h2>결제 정보를 찾을 수 없습니다</h2>
-              <button onClick={onHome} className="payment-button">
+              <p>결제는 정상적으로 처리되었지만, 상세 정보를 불러올 수 없습니다.</p>
+              <button onClick={onHome} className="home-button">
                 홈으로 돌아가기
               </button>
             </div>
@@ -180,18 +204,11 @@ const PaymentComplete = ({paymentData, onHome, onPaymentHistory}) => {
   }
 
   return (
-      <div className="payment-container">
-        <div className="payment-header">
-          <button className="back-button" onClick={onHome}>
-            <ArrowLeft className="icon" />
-          </button>
-          <h1>결제 완료</h1>
-        </div>
-
-        <div className="payment-content">
+      <div className="payment-complete-container">
+        <div className="payment-complete-content">
           {/* 성공 아이콘 및 메시지 */}
           <div className="payment-section">
-            <div className="success-header" style={{ textAlign: 'center', marginBottom: '2rem' }}>
+            <div className="payment-complete-success-header" style={{ textAlign: 'center', marginBottom: '2rem' }}>
               <div className="success-icon" style={{ marginBottom: '1rem' }}>
                 <CheckCircle size={80} style={{ color: '#22c55e' }}/>
               </div>
@@ -208,14 +225,14 @@ const PaymentComplete = ({paymentData, onHome, onPaymentHistory}) => {
                 <Receipt className="summary-icon" />
                 <div className="summary-info">
                   <span className="summary-label">주문번호</span>
-                  <span className="summary-value">{paymentData.orderId}</span>
+                  <span className="summary-value">{paymentData?.orderId || '주문번호 없음'}</span>
                 </div>
               </div>
               <div className="summary-item">
                 <CreditCard className="summary-icon" />
                 <div className="summary-info">
                   <span className="summary-label">결제금액</span>
-                  <span className="summary-value">{Number(paymentData.amount).toLocaleString()}원</span>
+                  <span className="summary-value">{safeFormatNumber(paymentData?.amount)}원</span>
                 </div>
               </div>
               <div className="summary-item">
@@ -229,7 +246,7 @@ const PaymentComplete = ({paymentData, onHome, onPaymentHistory}) => {
                 <Clock className="summary-icon" />
                 <div className="summary-info">
                   <span className="summary-label">결제일시</span>
-                  <span className="summary-value">{formatDate(paymentData.approvedAt || new Date())}</span>
+                  <span className="summary-value">{formatDate(paymentData?.approvedAt)}</span>
                 </div>
               </div>
             </div>
@@ -280,17 +297,17 @@ const PaymentComplete = ({paymentData, onHome, onPaymentHistory}) => {
             <div className="price-breakdown">
               <div className="price-item">
                 <span>서비스 이용료</span>
-                <span>{Number(bookingInfo.originalAmount || paymentData.amount).toLocaleString()}원</span>
+                <span>{safeFormatNumber(bookingInfo.originalAmount || paymentData?.amount)}원</span>
               </div>
-              {bookingInfo.discountAmount > 0 && (
+              {safeNumber(bookingInfo.discountAmount) > 0 && (
                   <div className="price-item discount">
                     <span>🎫 쿠폰 할인</span>
-                    <span>-{Number(bookingInfo.discountAmount).toLocaleString()}원</span>
+                    <span>-{safeFormatNumber(bookingInfo.discountAmount)}원</span>
                   </div>
               )}
               <div className="price-item total">
                 <span>총 결제금액</span>
-                <span>{Number(paymentData.amount).toLocaleString()}원</span>
+                <span>{safeFormatNumber(paymentData?.amount)}원</span>
               </div>
             </div>
           </div>
@@ -374,9 +391,8 @@ const PaymentComplete = ({paymentData, onHome, onPaymentHistory}) => {
               홈으로 돌아가기
             </button>
             {onPaymentHistory && (
-                <button className="payment-button hover:bg-gray-600" onClick={onPaymentHistory} style={{ 
-                  flex: 1, 
-                  backgroundColor: '#6b7280'
+                <button className="secondary-button" onClick={onPaymentHistory} style={{ 
+                  flex: 1
                 }}>
                   <Calendar className="icon" />
                   내 예약 보기

--- a/frontend/src/components/PaymentHistory.css
+++ b/frontend/src/components/PaymentHistory.css
@@ -21,7 +21,7 @@
   text-align: center;
 }
 
-.loading-spinner {
+.payment-history-loading-spinner {
   width: 50px;
   height: 50px;
   border: 4px solid rgba(255, 255, 255, 0.3);
@@ -44,7 +44,7 @@
   margin-bottom: 2rem;
 }
 
-.back-button {
+.payment-history-back-button {
   background: rgba(255, 255, 255, 0.2);
   border: none;
   padding: 0.75rem;
@@ -55,12 +55,12 @@
   backdrop-filter: blur(10px);
 }
 
-.back-button:hover {
+.payment-history-back-button:hover {
   background: rgba(255, 255, 255, 0.3);
   transform: translateY(-2px);
 }
 
-.back-button .icon {
+.payment-history-back-button .icon {
   width: 1.5rem;
   height: 1.5rem;
 }

--- a/frontend/src/components/PaymentHistory.jsx
+++ b/frontend/src/components/PaymentHistory.jsx
@@ -175,7 +175,7 @@ const PaymentHistory = ({ onBack }) => {
     return (
       <div className="payment-history-container">
         <div className="loading-section">
-          <div className="loading-spinner"></div>
+          <div className="payment-history-loading-spinner"></div>
           <h2>결제 내역을 불러오고 있습니다...</h2>
         </div>
       </div>
@@ -187,7 +187,7 @@ const PaymentHistory = ({ onBack }) => {
       <div className="payment-history-content">
         {/* 헤더 */}
         <div className="history-header">
-          <button className="back-button" onClick={onBack}>
+          <button className="payment-history-back-button" onClick={onBack}>
             <ArrowLeft className="icon" />
           </button>
           <h1>결제 내역</h1>

--- a/frontend/src/components/PaymentSuccess.css
+++ b/frontend/src/components/PaymentSuccess.css
@@ -11,7 +11,7 @@
 }
 
 /* 성공 헤더 */
-.success-header {
+.payment-success-header {
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(10px);
   padding: 2rem 1.5rem;
@@ -372,7 +372,7 @@
     padding: 1rem;
   }
   
-  .success-header {
+  .payment-success-header {
     padding: 1.5rem 1rem;
   }
   

--- a/frontend/src/components/PaymentSuccess.jsx
+++ b/frontend/src/components/PaymentSuccess.jsx
@@ -46,7 +46,7 @@ const PaymentSuccess = ({ paymentResult, onHome }) => {
     <div className="payment-success-container">
       <div className="payment-success-content">
         {/* 성공 아이콘 및 메시지 */}
-        <div className="success-header">
+        <div className="payment-success-header">
           <div className="success-icon">
             <CheckCircle size={80} />
           </div>

--- a/frontend/src/components/TossPayment.jsx
+++ b/frontend/src/components/TossPayment.jsx
@@ -118,8 +118,8 @@ function TossPaymentComponent({
     const initializeCustomerInfo = async () => {
       if (bookingData) {
 
-        // ❌ 하드코딩 제거: DB 값만 사용
-        const dbAmount = bookingData.servicePrice || bookingData.totalPrice;
+        // ✅ 할인된 최종 금액 사용 (Payment.jsx에서 전달된 servicePrice는 이미 할인 적용됨)
+        const dbAmount = bookingData.servicePrice || bookingData.finalPrice || bookingData.totalPrice;
         const dbOrderName = bookingData.serviceName || bookingData.orderName;
 
         if (!dbAmount) {
@@ -393,7 +393,7 @@ function TossPaymentComponent({
         const prepareData = await paymentAPI.preparePayment({
           reservationId: Number(reservationId),
           ticketId: Number(ticketId),
-          amount: Number(amount),
+          amount: Number(amount), // 이미 할인된 최종 금액
           couponId: bookingData?.selectedCoupon?.id ? Number(
               bookingData.selectedCoupon.id) : null
         });

--- a/frontend/src/components/TossPaymentSuccess.jsx
+++ b/frontend/src/components/TossPaymentSuccess.jsx
@@ -26,19 +26,22 @@ function TossPaymentSuccess({paymentData, onHome, onBack, onTossSuccess}) {
     // sessionStorage에서 결제 데이터 복원
     const savedPaymentData = sessionStorage.getItem('tossPaymentData');
     let reservationId = "";
+    let finalAmount = amount; // URL 파라미터의 amount (할인 전 원가)
 
     if (savedPaymentData) {
       try {
         const parsedData = JSON.parse(savedPaymentData);
         reservationId = parsedData.reservationId || "";
 
-        // URL에서 orderId나 amount가 없으면 저장된 데이터 사용
+        // ✅ 중요: sessionStorage에 저장된 할인된 금액을 우선 사용
+        if (parsedData.amount) {
+          finalAmount = parsedData.amount.toString();
+          console.log('🔍 금액 우선순위 - sessionStorage:', parsedData.amount, 'URL 파라미터:', amount);
+        }
+        
+        // URL에서 orderId가 없으면 저장된 데이터 사용
         if (!orderId && parsedData.orderId) {
           setPaymentInfo(prev => ({...prev, orderId: parsedData.orderId}));
-        }
-        if (!amount && parsedData.amount) {
-          setPaymentInfo(
-              prev => ({...prev, amount: parsedData.amount.toString()}));
         }
       } catch (e) {
         console.error('저장된 결제 데이터 파싱 실패:', e);
@@ -49,7 +52,18 @@ function TossPaymentSuccess({paymentData, onHome, onBack, onTossSuccess}) {
         || sessionStorage?.getItem("accessToken");
 
     setJwtToken(tokenFromStorage || "");
-    setPaymentInfo({paymentKey, orderId, amount, reservationId});
+    
+    // ✅ finalAmount 사용 (할인된 금액)
+    setPaymentInfo({paymentKey, orderId, amount: finalAmount, reservationId});
+    
+    console.log('📋 최종 결제 정보 설정:', {
+      paymentKey,
+      orderId, 
+      amount: finalAmount,
+      reservationId,
+      urlAmount: amount,
+      savedAmount: savedPaymentData ? JSON.parse(savedPaymentData).amount : 'none'
+    });
   }, []);
 
   // 🚀 자동 승인 처리 - 결제 정보가 준비되면 즉시 실행


### PR DESCRIPTION
Payment.jsx의 모든 CSS 클래스에 payment- 접두사를 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 결제 관련 화면 전반의 CSS 클래스명을 일관성 있게 접두사(`payment-`, `payment-complete-`, `payment-history-`, `payment-success-`)로 변경하여 스타일 적용 범위를 명확히 했습니다.
  * 결제 완료 화면에 새로운 스타일이 추가되어 UI가 개선되었습니다.

* **Bug Fixes**
  * 결제 금액 전달 및 표시 로직이 할인 적용 금액을 일관되게 반영하도록 수정되었습니다.
  * 결제 완료 화면에서 잘못된 값이나 누락된 데이터에 대한 표시 및 오류 처리가 강화되었습니다.

* **New Features**
  * 결제 완료 화면에 안전한 숫자 포맷팅 및 날짜 표시 기능이 추가되어 데이터 표시의 신뢰성이 높아졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->