### PR TITLE
hotfix: 임시로 booking의 현재 시간 + 10분 삭제

### DIFF
--- a/frontend/src/components/Booking.jsx
+++ b/frontend/src/components/Booking.jsx
@@ -96,7 +96,7 @@ const Booking = ({ mentor, onBack, onBooking }) => {
       
       if (isToday) {
         const currentTime = new Date();
-        const minBookingTime = new Date(currentTime.getTime() + 10 * 60000); // 현재 시간 + 10분
+        const minBookingTime = new Date(currentTime.getTime()); // 현재 시간 + 10분  ( + 10 * 60000)
         const minBookingTimeStr = `${minBookingTime.getHours().toString().padStart(2, '0')}:${minBookingTime.getMinutes().toString().padStart(2, '0')}`;
         
         uniqueSortedSlots = uniqueSortedSlots.filter(slot => {


### PR DESCRIPTION
hotfix: 임시로 booking의 현재 시간 + 10분 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 당일 예약 시 최소 예약 가능 시간이 현재 시간부터로 변경되어, 즉시 예약이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->