### PR TITLE
fix: websocket 제발;

### DIFF
--- a/frontend/src/services/websocket.js
+++ b/frontend/src/services/websocket.js
@@ -17,12 +17,8 @@ class WebSocketService {
   }
 
   async connect() {
-    // JWT 토큰 만료 문제로 인한 무한 재연결 방지를 위해 연결 완전 차단
-    console.error('🚫 WebSocket 연결이 완전히 비활성화되었습니다');
-    console.error('💡 JWT 토큰 만료로 인한 무한 재연결을 방지하기 위함입니다');
-    console.error('💡 새로운 유효한 토큰을 획득한 후 이 코드를 수정하세요');
-    this.emit('connectionFailed', new Error('WebSocket connection disabled'));
-    return;
+    // WebSocket 연결 활성화 (이전에 비활성화되었던 코드를 수정)
+    console.log('🔌 WebSocket 연결 시작...');
 
     try {
       // 이전 인증 실패로 인한 연결 차단 확인
@@ -64,7 +60,12 @@ class WebSocketService {
         throw new Error('No valid token available for WebSocket connection');
       }
 
-      const socketUrl = 'ws://localhost:8080/ws-nest/websocket';
+      // WebSocket URL 동적 생성 (프로덕션/개발 환경 구분)
+      const isProduction = window.location.protocol === 'https:';
+      const protocol = isProduction ? 'wss:' : 'ws:';
+      const host = isProduction ? 'nest-dev.click' : 'localhost:8080';
+      const socketUrl = `${protocol}//${host}/ws-nest/websocket`;
+      console.log('🔌 WebSocket URL:', socketUrl);
       const socket = new WebSocket(socketUrl);
 
       this.stompClient = new Client({

--- a/frontend/src/services/websocketService.js
+++ b/frontend/src/services/websocketService.js
@@ -68,7 +68,11 @@ class WebSocketService {
         }
 
         // WebSocket URL에 토큰을 파라미터로 추가
-        const baseUrl = import.meta.env.VITE_WS_URL || 'ws://localhost:8080';
+        // 프로덕션에서는 wss:// 사용, 개발환경에서는 ws:// 사용
+        const isProduction = window.location.protocol === 'https:';
+        const protocol = isProduction ? 'wss:' : 'ws:';
+        const host = isProduction ? 'nest-dev.click' : 'localhost:8080';
+        const baseUrl = import.meta.env.VITE_WS_URL || `${protocol}//${host}`;
         const wsUrl = `${baseUrl}/ws-nest/websocket?token=${encodeURIComponent(this.websocketToken)}`;
         console.log('🔌 WebSocket 연결 시도 (토큰 파라미터):', baseUrl + '/ws-nest/websocket?token=***');
         


### PR DESCRIPTION
웹소켓 이슈

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * WebSocket 연결이 JWT 토큰 만료로 인해 항상 차단되던 문제가 해결되어, 연결이 정상적으로 재시도됩니다.

* **개선 사항**
  * WebSocket 연결 시 환경에 따라 URL이 자동으로 설정되어, HTTPS 환경에서는 보안 연결(wss) 및 프로덕션 호스트를, 개발 환경에서는 일반 연결(ws) 및 로컬 호스트를 사용합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->